### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     # Run e2e tests daily at 2 AM UTC
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}


### PR DESCRIPTION
Potential fix for [https://github.com/random-iceberg/docker-compose/security/code-scanning/1](https://github.com/random-iceberg/docker-compose/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, such as checking out code, logging into the GitHub Container Registry, and running Docker commands, the following permissions are required:
- `contents: read` for accessing repository contents.
- `packages: write` for logging into the GitHub Container Registry and pulling/pushing images.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
