### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     # Run e2e tests daily at 2 AM UTC
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}


### PR DESCRIPTION
Potential fix for [https://github.com/random-iceberg/docker-compose/security/code-scanning/2](https://github.com/random-iceberg/docker-compose/security/code-scanning/2)

To fix the issue, we will add an explicit `permissions` block to the workflow. This block will be added at the root level of the workflow to apply to all jobs unless overridden by a job-specific `permissions` block. Based on the workflow's operations, the minimal required permissions are:
- `contents: read` for accessing the repository's contents.
- `packages: read` for pulling container images from the GitHub Container Registry.
- `statuses: write` for updating commit statuses.

This ensures that the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
