### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     # Run e2e tests daily at 2 AM UTC
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}


### PR DESCRIPTION
Potential fix for [https://github.com/random-iceberg/docker-compose/security/code-scanning/3](https://github.com/random-iceberg/docker-compose/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves checking out code and interacting with the GitHub Container Registry, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for interacting with the GitHub Container Registry.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions per job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
